### PR TITLE
Add support for scenes

### DIFF
--- a/src/dirigera/devices/scene.py
+++ b/src/dirigera/devices/scene.py
@@ -15,7 +15,7 @@ class Scene:
         self.dirigera_client.post(route=f"/scenes/{self.scene_id}/trigger")
 
 
-def dict_to_scene(data: Dict[str, Any], dirigera_client: AbstractSmartHomeHub):
+def dict_to_scene(data: Dict[str, Any], dirigera_client: AbstractSmartHomeHub) -> Scene:
     return Scene(
         dirigera_client=dirigera_client,
         scene_id=data["id"],

--- a/src/dirigera/devices/scene.py
+++ b/src/dirigera/devices/scene.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+from typing import Dict, Any
+
+from ..hub.abstract_smart_home_hub import AbstractSmartHomeHub
+
+
+@dataclass
+class Scene:
+    dirigera_client: AbstractSmartHomeHub
+    scene_id: str
+    name: str
+    icon: str
+
+    def trigger(self):
+        self.dirigera_client.post(route=f"/scenes/{self.scene_id}/trigger")
+
+
+def dict_to_scene(data: Dict[str, Any], dirigera_client: AbstractSmartHomeHub):
+    return Scene(
+        dirigera_client=dirigera_client,
+        scene_id=data["id"],
+        name=data["info"]["name"],
+        icon=data["info"]["icon"]
+    )

--- a/src/dirigera/hub/abstract_smart_home_hub.py
+++ b/src/dirigera/hub/abstract_smart_home_hub.py
@@ -12,7 +12,7 @@ class AbstractSmartHomeHub(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def post(self, route: str, data: Optional[Dict[str,Any]]=None) -> Dict[str, Any]:
+    def post(self, route: str, data: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
         raise NotImplementedError
 
 
@@ -30,5 +30,5 @@ class FakeDirigeraHub(AbstractSmartHomeHub):
         self.get_actions.append({"route": route})
         return self.get_action_replys[route]
 
-    def post(self, route: str, data: Optional[Dict[str,Any]]=None) -> Dict[str, Any]:
+    def post(self, route: str, data: Optional[Dict[str, Any]] = None) -> None:
         self.post_actions.append({"route": route, "data": data})

--- a/src/dirigera/hub/abstract_smart_home_hub.py
+++ b/src/dirigera/hub/abstract_smart_home_hub.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 
 class AbstractSmartHomeHub(abc.ABC):
@@ -11,10 +11,15 @@ class AbstractSmartHomeHub(abc.ABC):
     def get(self, route: str) -> Dict[str, Any]:
         raise NotImplementedError
 
+    @abc.abstractmethod
+    def post(self, route: str, data: Optional[Dict[str,Any]]=None) -> Dict[str, Any]:
+        raise NotImplementedError
+
 
 class FakeDirigeraHub(AbstractSmartHomeHub):
     def __init__(self) -> None:
         self.patch_actions: List = []
+        self.post_actions: List = []
         self.get_actions: List = []
         self.get_action_replys: Dict = {}
 
@@ -24,3 +29,6 @@ class FakeDirigeraHub(AbstractSmartHomeHub):
     def get(self, route: str) -> Dict[str, Any]:
         self.get_actions.append({"route": route})
         return self.get_action_replys[route]
+
+    def post(self, route: str, data: Optional[Dict[str,Any]]=None) -> Dict[str, Any]:
+        self.post_actions.append({"route": route, "data": data})

--- a/src/dirigera/hub/hub.py
+++ b/src/dirigera/hub/hub.py
@@ -101,7 +101,7 @@ class Hub(AbstractSmartHomeHub):
         response.raise_for_status()
 
         if len(response.content) == 0:
-            return
+            return None
 
         return response.json()
 

--- a/src/dirigera/hub/hub.py
+++ b/src/dirigera/hub/hub.py
@@ -78,7 +78,7 @@ class Hub(AbstractSmartHomeHub):
             verify=False,
         )
         response.raise_for_status()
-        return response.json()
+        return response.text
 
     def get(self, route: str) -> Dict[str, Any]:
         response = requests.get(

--- a/tests/test_scenes.py
+++ b/tests/test_scenes.py
@@ -1,0 +1,43 @@
+import pytest
+from src.dirigera.hub.abstract_smart_home_hub import FakeDirigeraHub
+from src.dirigera.devices.scene import Scene, dict_to_scene
+
+TEST_ID = "00000000-0000-0000-0000-000000000000"
+TEST_NAME = "NAME"
+TEST_ICON = "ICON"
+
+
+@pytest.fixture(name="fake_client")
+def fixture_fake_client():
+    return FakeDirigeraHub()
+
+
+@pytest.fixture(name="fake_scene")
+def fixture_scene(fake_client: FakeDirigeraHub):
+    return Scene(
+        dirigera_client=fake_client,
+        scene_id=TEST_ID,
+        name=TEST_NAME,
+        icon=TEST_ICON
+    )
+
+
+def test_trigger(fake_scene, fake_client) -> None:
+    fake_scene.trigger()
+    action = fake_client.post_actions.pop()
+    assert action["route"] == f"/scenes/{fake_scene.scene_id}/trigger"
+
+
+def test_dict_to_scene(fake_client):
+    data = {
+        "id": TEST_ID,
+        "info": {
+            "name": TEST_NAME,
+            "icon": TEST_ICON
+        }
+    }
+
+    scene = dict_to_scene(data, fake_client)
+    assert scene.scene_id == TEST_ID
+    assert scene.name == TEST_NAME
+    assert scene.icon == TEST_ICON


### PR DESCRIPTION
Implemented parts of /scene api.
Added:
- Post to AbstractSmartHomeHub (required by /scene/<id>/trigger)
- New class Scene with attributes scene_id, name and icon
- Scene.trigger() to activate a scene
- Hub.get_scenes()
- Hub.get_scene_by_id(scene_id)