### PR TITLE
Scene status times

### DIFF
--- a/src/dirigera/devices/scene.py
+++ b/src/dirigera/devices/scene.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 from ..hub.abstract_smart_home_hub import AbstractSmartHomeHub
 
@@ -10,9 +10,9 @@ class Scene:
     scene_id: str
     name: str
     icon: str
-    last_completed: str
-    last_triggered: str
-    last_undo: str
+    last_completed: Optional[str]
+    last_triggered: Optional[str]
+    last_undo: Optional[str]
 
     def trigger(self) -> None:
         self.dirigera_client.post(route=f"/scenes/{self.scene_id}/trigger")
@@ -27,7 +27,7 @@ def dict_to_scene(data: Dict[str, Any], dirigera_client: AbstractSmartHomeHub) -
         scene_id=data["id"],
         name=data["info"]["name"],
         icon=data["info"]["icon"],
-        last_completed=data["lastCompleted"],
-        last_triggered=data["lastTriggered"],
-        last_undo=data["lastUndo"]
+        last_completed=data.get("lastCompleted"),
+        last_triggered=data.get("lastTriggered"),
+        last_undo=data.get("lastUndo")
     )

--- a/src/dirigera/devices/scene.py
+++ b/src/dirigera/devices/scene.py
@@ -22,7 +22,7 @@ class Scene:
         self.last_completed=data.get("lastCompleted")
         self.last_triggered=data.get("lastTriggered")
         self.last_undo=data.get("lastUndo")
-        
+
 
     def trigger(self) -> None:
         self.dirigera_client.post(route=f"/scenes/{self.scene_id}/trigger")

--- a/src/dirigera/devices/scene.py
+++ b/src/dirigera/devices/scene.py
@@ -14,6 +14,16 @@ class Scene:
     last_triggered: Optional[str]
     last_undo: Optional[str]
 
+    def refresh(self) -> None:
+        data = self.dirigera_client.get(route=f"/scenes/{self.scene_id}")
+        self.scene_id = data["id"]
+        self.name = data["info"]["name"]
+        self.icon = data["info"]["icon"]
+        self.last_completed=data.get("lastCompleted")
+        self.last_triggered=data.get("lastTriggered")
+        self.last_undo=data.get("lastUndo")
+        
+
     def trigger(self) -> None:
         self.dirigera_client.post(route=f"/scenes/{self.scene_id}/trigger")
 


### PR DESCRIPTION
timestamps are optional since a scene may have never been triggered or undone. Also, a refresh method was needed to sync scene data from the hub.