### PR TITLE
fix: Make `color_hue` on `LightAttributes` float

### DIFF
--- a/src/dirigera/devices/light.py
+++ b/src/dirigera/devices/light.py
@@ -11,7 +11,7 @@ class LightAttributes(Attributes):
     color_temperature: Optional[int] = None
     color_temperature_min: Optional[int] = None
     color_temperature_max: Optional[int] = None
-    color_hue: Optional[int] = None
+    color_hue: Optional[float] = None
     color_saturation: Optional[float] = None
 
 


### PR DESCRIPTION
IKEA lights that has color support may return the hue as a float. To support this the type on the class must match that.

---

Thanks for an amazing project!

I just discovered the project and it was super easy to get up and running, however the first thing that happened to me was that I hit an issue with the Pydantic validation. I have a [light with color support](https://www.ikea.com/nl/en/p/tradfri-led-bulb-e27-806-lumen-smart-wireless-dimmable-colour-and-white-spectrum-globe-70439158/) and the Dirigera will return the `color_hue` as a float:

```python
Traceback (most recent call last):
  File "/home/simon/git/dirigera-test/./main.py", line 10, in <module>
    lights = dirigera_hub.get_lights()
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/simon/.pyenv/versions/3.11.2/lib/python3.11/site-packages/dirigera/hub/hub.py", line 112, in get_lights
    return [dict_to_light(light, self) for light in lights]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/simon/.pyenv/versions/3.11.2/lib/python3.11/site-packages/dirigera/hub/hub.py", line 112, in <listcomp>
    return [dict_to_light(light, self) for light in lights]
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/simon/.pyenv/versions/3.11.2/lib/python3.11/site-packages/dirigera/devices/light.py", line 109, in dict_to_light
    return Light(
           ^^^^^^
  File "/home/simon/.pyenv/versions/3.11.2/lib/python3.11/site-packages/pydantic/main.py", line 164, in __init__
    __pydantic_self__.__pydantic_validator__.validate_python(data, self_instance=__pydantic_self__)
pydantic_core._pydantic_core.ValidationError: 1 validation error for Light
attributes.colorHue
  Input should be a valid integer, got a number with a fractional part [type=int_from_float, input_value=29.999024463361252, input_type=float]
    For further information visit https://errors.pydantic.dev/2.4/v/int_from_float
```

I only have one of these bulbs (it's a couple of years old) so I don't know if it's unique for this, the old version or something else, however since it obviously _can_ happen I think the value for the hue should be represented as a float. With this fix, this is the output for my lights:

```python
for light in dirigera_hub.get_lights():
    print(f"name={light.id}, hue={light.attributes.color_hue}")
```

```text
name=222a6c35-337a-4191-801c-e993fdf17259_1, hue=None
name=ede1538a-00c6-445e-9a48-c4c1eb6e65e8_1, hue=None
name=3b1a04db-9abe-4811-b60a-797970f51e8a_1, hue=334.9346923828125
name=86a0fac2-d213-42bb-b1c1-00533ba468cd_1, hue=None
name=e0e35a0c-29e8-4703-b87c-a51e6aef2b94_1, hue=None
name=5050d647-58cc-4bd5-bbc6-40d4d4eaa323_1, hue=None
```