### PR TITLE
Make project compatible with older pydantic versions (1.10.*)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dirigera"
-version = "1.0.2"
+version = "1.0.3"
 description = "An unofficial Python client for controlling the IKEA Dirigera Smart Home Hub"
 readme = "README.md"
 authors = [{ name = "Leggin", email = "legginsun@gmail.com" }]
@@ -22,7 +22,7 @@ keywords = [
 dependencies = [
     "requests >= 2.22.0",
     "websocket-client >= 1.0.0",
-    "pydantic >= 2.0",
+    "pydantic >= 1.10.0",
 ]
 requires-python = ">=3.7"
 classifiers = [

--- a/src/dirigera/devices/base_ikea_model.py
+++ b/src/dirigera/devices/base_ikea_model.py
@@ -1,7 +1,10 @@
-from pydantic import BaseModel, ConfigDict, alias_generators
+from pydantic import BaseModel
 
 
-class BaseIkeaModel(BaseModel):
-    model_config = ConfigDict(
-        alias_generator=alias_generators.to_camel, arbitrary_types_allowed=True
-    )
+def to_camel(string: str) -> str:
+    string_split = string.split("_")
+    return string_split[0] + "".join(word.capitalize() for word in string_split[1:])
+
+
+class BaseIkeaModel(BaseModel, arbitrary_types_allowed=True, alias_generator=to_camel):
+    pass

--- a/src/dirigera/devices/scene.py
+++ b/src/dirigera/devices/scene.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 import datetime
 from typing import Dict, Any, List, Optional
-from pydantic import ConfigDict
 from .base_ikea_model import BaseIkeaModel
 from .device import Attributes
 from ..hub.abstract_smart_home_hub import AbstractSmartHomeHub
@@ -28,8 +27,8 @@ class Trigger(BaseIkeaModel):
     disabled: bool
 
 
-class ActionAttributes(BaseIkeaModel):
-    model_config = ConfigDict(extra="allow")
+class ActionAttributes(BaseIkeaModel, extra="allow"):
+    pass
 
 
 class Action(BaseIkeaModel):


### PR DESCRIPTION
In this PR the alias generator from pydantic is replaced by a custom one. The config for pydantic models is moved out of the ConfigDict. 