### PR TITLE
Room is optional for new SOMRIG shortcut button and probably others

### DIFF
--- a/src/dirigera/devices/device.py
+++ b/src/dirigera/devices/device.py
@@ -49,7 +49,7 @@ class Device(BaseIkeaModel):
     last_seen: datetime.datetime
     attributes: Attributes
     capabilities: Capabilities
-    room: Room
+    room: Optional[Room] = None
     device_set: List
     remote_links: List[str]
     is_hidden: Optional[bool] = None


### PR DESCRIPTION
Hi, 
I found bug. When I connected new type SOMRIG shortcut button i got error in validation. 
![image](https://github.com/Leggin/dirigera/assets/33373409/bb79a98a-027b-43b4-a227-055b1805fa1e)

```python
Traceback (most recent call last):
  File "/Users/slajob/git/dirigera_local/test.py", line 10, in <module>
    print(dirigera_hub.get_controllers())
  File "/Users/slajob/git/dirigera_local/venv/lib/python3.9/site-packages/dirigera/hub/hub.py", line 237, in get_controllers
    return [dict_to_controller(controller, self) for controller in controllers]
  File "/Users/slajob/git/dirigera_local/venv/lib/python3.9/site-packages/dirigera/hub/hub.py", line 237, in <listcomp>
    return [dict_to_controller(controller, self) for controller in controllers]
  File "/Users/slajob/git/dirigera_local/venv/lib/python3.9/site-packages/dirigera/devices/controller.py", line 34, in dict_to_controller
    return Controller(dirigeraClient=dirigera_client, **data)
  File "/Users/slajob/git/dirigera_local/venv/lib/python3.9/site-packages/pydantic/main.py", line 171, in __init__
    self.__pydantic_validator__.validate_python(data, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 1 validation error for Controller
room
  Field required [type=missing, input_value={'dirigeraClient': <dirig...: [], 'isHidden': False}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.6/v/missing
```
So I checked my raw api return https://192.168.0.74:8443/v1/devices and old TRADFRI shortcut button json is:
```json
    {
        "id": "1a33ec9b-0f58-4bdd-94b6-99c3823fc234_1",
        "type": "controller",
        "deviceType": "shortcutController",
        "createdAt": "2023-12-17T13:14:55.000Z",
        "isReachable": true,
        "lastSeen": "2024-03-13T01:03:41.000Z",
        "attributes": {
            "customName": "Shortcut button",
            "model": "TRADFRI SHORTCUT Button",
            "manufacturer": "IKEA of Sweden",
            "firmwareVersion": "24.4.6",
            "hardwareVersion": "1",
            "serialNumber": "DC8E95FFFE89D2BC",
            "productCode": "E1812",
            "batteryPercentage": 50,
            "isOn": false,
            "lightLevel": 1,
            "permittingJoin": false,
            "otaStatus": "upToDate",
            "otaState": "readyToCheck",
            "otaProgress": 0,
            "otaPolicy": "autoUpdate",
            "otaScheduleStart": "00:00",
            "otaScheduleEnd": "00:00"
        },
        "capabilities": {
            "canSend": [
                "singlePress",
                "doublePress",
                "longPress"
            ],
            "canReceive": [
                "customName"
            ]
        },
        "room": {
            "id": "19df992a-d048-4c68-9743-f7f81a884144",
            "name": "Living room",
            "color": "ikea_green_no_65",
            "icon": "rooms_sofa"
        },
        "deviceSet": [],
        "remoteLinks": [],
        "isHidden": false
    }
```

and new SOMRIG shortcut button json is:
```json
    {
        "id": "b55c75ec-829c-4623-a167-0b537569c9e2_2",
        "relationId": "b55c75ec-829c-4623-a167-0b537569c9e2",
        "type": "controller",
        "deviceType": "shortcutController",
        "createdAt": "2023-12-16T17:30:10.000Z",
        "isReachable": true,
        "lastSeen": "2024-03-13T12:38:43.000Z",
        "attributes": {
            "customName": "",
            "model": "SOMRIG shortcut button",
            "manufacturer": "IKEA of Sweden",
            "firmwareVersion": "1.0.20",
            "hardwareVersion": "1",
            "serialNumber": "287681FFFE4B8FBC",
            "productCode": "E2213",
            "switchLabel": "Shortcut 2",
            "isOn": false,
            "lightLevel": 1,
            "permittingJoin": false,
            "otaStatus": "upToDate",
            "otaState": "readyToCheck",
            "otaProgress": 0,
            "otaPolicy": "autoUpdate",
            "otaScheduleStart": "00:00",
            "otaScheduleEnd": "00:00"
        },
        "capabilities": {
            "canSend": [
                "singlePress",
                "longPress",
                "doublePress",
                "singlePress",
                "doublePress",
                "longPress"
            ],
            "canReceive": [
                "customName"
            ]
        },
        "deviceSet": [],
        "remoteLinks": [],
        "isHidden": false
    },
```
So you can notice there is a room parameter missing. 
After this small change Room to optional I received controllers correctly: 
```json
[Controller(id='3d754a71-86b4-46f2-9885-85ddb32dbb35_1', type='controller', device_type='blindsController', created_at=datetime.datetime(2023, 11, 18, 18, 23, 31, tzinfo=TzInfo(UTC)), is_reachable=True, last_seen=datetime.datetime(2024, 3, 13, 7, 56, 39, tzinfo=TzInfo(UTC)), attributes=ControllerAttributes(custom_name='Kitchen blind remote', model='TRADFRI open/close remote', manufacturer='IKEA of Sweden', firmware_version='24.4.6', hardware_version='1', serial_number='842E14FFFE73FA73', product_code='E1766', ota_status='upToDate', ota_state='readyToCheck', ota_progress=0, ota_policy='autoUpdate', ota_schedule_start=datetime.time(0, 0), ota_schedule_end=datetime.time(0, 0), is_on=False, battery_percentage=50), capabilities=Capabilities(can_send=['isOn', 'lightLevel', 'blindsState'], can_receive=['customName']), room=Room(id='a40bc2b4-ffe6-4b63-9612-9d0dc8d9a394', name='Kitchen', color='ikea_blue_no_58', icon='rooms_kitchen'), device_set=[], remote_links=[], is_hidden=False, dirigera_client=<dirigera.hub.hub.Hub object at 0x10509dfd0>), Controller(id='edb20bcb-87d3-4be2-a6d5-4bd84efa13e1_1', type='controller', device_type='blindsController', created_at=datetime.datetime(2023, 7, 12, 4, 34, 18, tzinfo=TzInfo(UTC)), is_reachable=True, last_seen=datetime.datetime(2024, 3, 13, 2, 48, 54, tzinfo=TzInfo(UTC)), attributes=ControllerAttributes(custom_name='Left blind remote', model='TRADFRI open/close remote', manufacturer='IKEA of Sweden', firmware_version='24.4.6', hardware_version='1', serial_number='000D6FFFFED3CAEB', product_code='E1766', ota_status='upToDate', ota_state='readyToCheck', ota_progress=0, ota_policy='autoUpdate', ota_schedule_start=datetime.time(0, 0), ota_schedule_end=datetime.time(0, 0), is_on=False, battery_percentage=14), capabilities=Capabilities(can_send=['isOn', 'lightLevel', 'blindsState'], can_receive=['customName']), room=Room(id='19df992a-d048-4c68-9743-f7f81a884144', name='Living room', color='ikea_green_no_65', icon='rooms_sofa'), device_set=[], remote_links=[], is_hidden=False, dirigera_client=<dirigera.hub.hub.Hub object at 0x10509dfd0>), Controller(id='b55c75ec-829c-4623-a167-0b537569c9e2_1', type='controller', device_type='shortcutController', created_at=datetime.datetime(2023, 12, 16, 17, 30, 10, tzinfo=TzInfo(UTC)), is_reachable=True, last_seen=datetime.datetime(2024, 3, 13, 12, 38, 43, tzinfo=TzInfo(UTC)), attributes=ControllerAttributes(custom_name='Shortcut button 6', model='SOMRIG shortcut button', manufacturer='IKEA of Sweden', firmware_version='1.0.20', hardware_version='1', serial_number='287681FFFE4B8FBC', product_code='E2213', ota_status='upToDate', ota_state='readyToCheck', ota_progress=0, ota_policy='autoUpdate', ota_schedule_start=datetime.time(0, 0), ota_schedule_end=datetime.time(0, 0), is_on=False, battery_percentage=100), capabilities=Capabilities(can_send=['singlePress', 'longPress', 'doublePress', 'singlePress', 'doublePress', 'longPress'], can_receive=['customName']), room=Room(id='19df992a-d048-4c68-9743-f7f81a884144', name='Living room', color='ikea_green_no_65', icon='rooms_sofa'), device_set=[], remote_links=[], is_hidden=False, dirigera_client=<dirigera.hub.hub.Hub object at 0x10509dfd0>), Controller(id='b55c75ec-829c-4623-a167-0b537569c9e2_2', type='controller', device_type='shortcutController', created_at=datetime.datetime(2023, 12, 16, 17, 30, 10, tzinfo=TzInfo(UTC)), is_reachable=True, last_seen=datetime.datetime(2024, 3, 13, 12, 38, 43, tzinfo=TzInfo(UTC)), attributes=ControllerAttributes(custom_name='', model='SOMRIG shortcut button', manufacturer='IKEA of Sweden', firmware_version='1.0.20', hardware_version='1', serial_number='287681FFFE4B8FBC', product_code='E2213', ota_status='upToDate', ota_state='readyToCheck', ota_progress=0, ota_policy='autoUpdate', ota_schedule_start=datetime.time(0, 0), ota_schedule_end=datetime.time(0, 0), is_on=False, battery_percentage=None), capabilities=Capabilities(can_send=['singlePress', 'longPress', 'doublePress', 'singlePress', 'doublePress', 'longPress'], can_receive=['customName']), room=None, device_set=[], remote_links=[], is_hidden=False, dirigera_client=<dirigera.hub.hub.Hub object at 0x10509dfd0>), Controller(id='bde0f7eb-640c-4903-b2c9-f06415b28ba2_1', type='controller', device_type='blindsController', created_at=datetime.datetime(2023, 9, 8, 19, 45, 49, tzinfo=TzInfo(UTC)), is_reachable=True, last_seen=datetime.datetime(2024, 3, 13, 16, 39, 15, tzinfo=TzInfo(UTC)), attributes=ControllerAttributes(custom_name='Right Blind remote', model='TRADFRI open/close remote', manufacturer='IKEA of Sweden', firmware_version='24.4.6', hardware_version='1', serial_number='000D6FFFFE7B8F5A', product_code='E1766', ota_status='upToDate', ota_state='readyToCheck', ota_progress=0, ota_policy='autoUpdate', ota_schedule_start=datetime.time(0, 0), ota_schedule_end=datetime.time(0, 0), is_on=False, battery_percentage=1), capabilities=Capabilities(can_send=['isOn', 'lightLevel', 'blindsState'], can_receive=['customName']), room=Room(id='19df992a-d048-4c68-9743-f7f81a884144', name='Living room', color='ikea_green_no_65', icon='rooms_sofa'), device_set=[], remote_links=[], is_hidden=False, dirigera_client=<dirigera.hub.hub.Hub object at 0x10509dfd0>), Controller(id='1a33ec9b-0f58-4bdd-94b6-99c3823fc234_1', type='controller', device_type='shortcutController', created_at=datetime.datetime(2023, 12, 17, 13, 14, 55, tzinfo=TzInfo(UTC)), is_reachable=True, last_seen=datetime.datetime(2024, 3, 13, 1, 3, 41, tzinfo=TzInfo(UTC)), attributes=ControllerAttributes(custom_name='Shortcut button', model='TRADFRI SHORTCUT Button', manufacturer='IKEA of Sweden', firmware_version='24.4.6', hardware_version='1', serial_number='DC8E95FFFE89D2BC', product_code='E1812', ota_status='upToDate', ota_state='readyToCheck', ota_progress=0, ota_policy='autoUpdate', ota_schedule_start=datetime.time(0, 0), ota_schedule_end=datetime.time(0, 0), is_on=False, battery_percentage=50), capabilities=Capabilities(can_send=['singlePress', 'doublePress', 'longPress'], can_receive=['customName']), room=Room(id='19df992a-d048-4c68-9743-f7f81a884144', name='Living room', color='ikea_green_no_65', icon='rooms_sofa'), device_set=[], remote_links=[], is_hidden=False, dirigera_client=<dirigera.hub.hub.Hub object at 0x10509dfd0>)]
```