### PR TITLE
Make pm25 and voc optional

### DIFF
--- a/src/dirigera/devices/environment_sensor.py
+++ b/src/dirigera/devices/environment_sensor.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 from .device import Attributes, Device
 from ..hub.abstract_smart_home_hub import AbstractSmartHomeHub
 
@@ -7,10 +7,10 @@ from ..hub.abstract_smart_home_hub import AbstractSmartHomeHub
 class EnvironmentSensorAttributes(Attributes):
     current_temperature: float
     current_r_h: int
-    current_p_m25: int
-    max_measured_p_m25: int
-    min_measured_p_m25: int
-    voc_index: int
+    current_p_m25: Optional[int]
+    max_measured_p_m25: Optional[int]
+    min_measured_p_m25: Optional[int]
+    voc_index: Optional[int]
 
 
 class EnvironmentSensor(Device):


### PR DESCRIPTION
Dirigera currently supports third-party zigbee sensors, such as Aqara temperature sensors. 

These sensors may not necessarily have pm25 and voc attributes:

`{
    "attributes": {
        "currentRH": 49,
        "currentTemperature": 22.0100002288818,
        "customName": "aqara_sensor",
        "firmwareVersion": "",
        "hardwareVersion": "",
        "manufacturer": "AQARA",
        "model": "lumi.sensor_ht",
        "permittingJoin": false,
        "productCode": "WSDCGQ01LM",
        "serialNumber": "serialNumber"
    },
    "capabilities": {
        "canReceive": [
            "customName"
        ],
        "canSend": [
        ]
    },
    "createdAt": "2023-06-28T16:22:56.000Z",
    "deviceSet": [
    ],
    "deviceType": "environmentSensor",
    "id": "id",
    "isHidden": false,
    "isReachable": true,
    "lastSeen": "2024-03-24T14:53:28.000Z",
    "remoteLinks": [
    ],
    "room": {
        "color": "ikea_pink_no_6",
        "icon": "rooms_ladle",
        "id": "id",
        "name": "kitchen"
    },
    "type": "sensor"
}`