### PR TITLE
Make is_on optional

### DIFF
--- a/src/dirigera/devices/controller.py
+++ b/src/dirigera/devices/controller.py
@@ -5,7 +5,7 @@ from ..hub.abstract_smart_home_hub import AbstractSmartHomeHub
 
 
 class ControllerAttributes(Attributes):
-    is_on: bool
+    is_on: bool = None
     battery_percentage: Optional[int] = None
     switch_label: Optional[str] = None
 


### PR DESCRIPTION
The is_on bool is unavailable on some remotes/controllers, which causes Pydantic to crash the app. This change makes is_on optional.

Tested on STYRBAR E2002 and SYMFONISK sound remote gen2 E2123.