### PR TITLE
Update controller.py

### DIFF
--- a/src/dirigera/devices/controller.py
+++ b/src/dirigera/devices/controller.py
@@ -5,7 +5,7 @@ from ..hub.abstract_smart_home_hub import AbstractSmartHomeHub
 
 
 class ControllerAttributes(Attributes):
-    is_on: bool
+    is_on: Optional[bool] = None
     battery_percentage: Optional[int] = None
     switch_label: Optional[str] = None
 


### PR DESCRIPTION
Making is_on optional. New shortcut controllers from IKEA with the same deviceType as "controller" do not have isOn attribute in the JSON