### PR TITLE
Set battery_percentage to Optional[int] for motion and water sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,7 +562,7 @@ motions_sensors = dirigera_hub.get_motion_sensors()
 The motion sensor object has the following attributes (additional to the core attributes):
 
 ```python
-battery_percentage: int
+battery_percentage: Optional[int] = None
 is_on: bool
 light_level: Optional[float] = None
 is_detected: Optional[bool] = False

--- a/src/dirigera/devices/motion_sensor.py
+++ b/src/dirigera/devices/motion_sensor.py
@@ -5,7 +5,7 @@ from ..hub.abstract_smart_home_hub import AbstractSmartHomeHub
 
 
 class MotionSensorAttributes(Attributes):
-    battery_percentage: int
+    battery_percentage: Optional[int] = None
     is_on: bool
     light_level: Optional[float] = None
     is_detected: Optional[bool] = False

--- a/src/dirigera/devices/water_sensor.py
+++ b/src/dirigera/devices/water_sensor.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 from .device import Attributes, Device
 from ..hub.abstract_smart_home_hub import AbstractSmartHomeHub
 
 class WaterSensorAttributes(Attributes):
-    battery_percentage: int
+    battery_percentage: Optional[int] = None
     water_leak_detected: bool
 
 class WaterSensor(Device):

--- a/tests/test_motion_sensor.py
+++ b/tests/test_motion_sensor.py
@@ -9,6 +9,51 @@ def fixture_fake_client() -> FakeDirigeraHub:
     return FakeDirigeraHub()
 
 
+@pytest.fixture(name="motion_sensor_dict_non_ikea")
+def fixture_motion_sensor_dict_non_ikea() -> Dict:
+    return {
+        "id": "62e95143-c8b6-4f28-b581-adfd622c0db7_1",
+        "type": "sensor",
+        "deviceType": "motionSensor",
+        "createdAt": "2023-12-14T18:28:57.000Z",
+        "isReachable": True,
+        "lastSeen": "2023-12-14T17:30:48.000Z",
+        "attributes": {
+            "customName": "Bewegungssensor",
+            "firmwareVersion": "",
+            "hardwareVersion": "",
+            "manufacturer": "SONOFF",
+            "model": "Wireless Motion Sensor",
+            "productCode": "SNZB-03",
+            "serialNumber": "9",
+            "isOn": False,
+            "permittingJoin": False,
+            "sensorConfig": {
+                "scheduleOn": False,
+                "onDuration": 120,
+                "schedule": {
+                    "onCondition": {"time": "sunset", "offset": -60},
+                    "offCondition": {"time": "sunrise", "offset": 60},
+                },
+            },
+            "circadianPresets": [],
+        },
+        "capabilities": {
+            "canSend": ["isOn", "lightLevel"],
+            "canReceive": ["customName"],
+        },
+        "room": {
+            "id": "e1631a64-9ceb-4113-a6b3-1d866216503c",
+            "name": "Zimmer",
+            "color": "ikea_beige_1",
+            "icon": "rooms_arm_chair",
+        },
+        "deviceSet": [],
+        "remoteLinks": [],
+        "isHidden": False,
+    }
+
+
 @pytest.fixture(name="motion_sensor_dict")
 def fixture_motion_sensor_dict() -> Dict:
     return {
@@ -84,7 +129,7 @@ def test_set_motion_sensor_name(
     assert fake_motion_sensor.attributes.custom_name == new_name
 
 
-def test_dict_to_blind(motion_sensor_dict: Dict, fake_client: FakeDirigeraHub) -> None:
+def test_dict_to_motion_sensor(motion_sensor_dict: Dict, fake_client: FakeDirigeraHub) -> None:
     motion_sensor = dict_to_motion_sensor(motion_sensor_dict, fake_client)
     assert motion_sensor.dirigera_client == fake_client
     assert motion_sensor.id == motion_sensor_dict["id"]
@@ -121,3 +166,8 @@ def test_dict_to_blind(motion_sensor_dict: Dict, fake_client: FakeDirigeraHub) -
         motion_sensor.attributes.manufacturer
         == motion_sensor_dict["attributes"]["manufacturer"]
     )
+
+def test_dict_to_motion_sensor_optional_fields(motion_sensor_dict_non_ikea: Dict, fake_client: FakeDirigeraHub) -> None:
+    motion_sensor = dict_to_motion_sensor(motion_sensor_dict_non_ikea, fake_client)
+
+    assert motion_sensor.attributes.battery_percentage is None

--- a/tests/test_water_sensor.py
+++ b/tests/test_water_sensor.py
@@ -9,6 +9,45 @@ def fixture_fake_client() -> FakeDirigeraHub:
     return FakeDirigeraHub()
 
 
+@pytest.fixture(name="fake_water_sensor_dict_non_ikea")
+def fixture_water_sensor_dict_non_ikea() -> Dict:
+    return {
+        "id": "2b107b0b-73f0-4809-a900-4783273d7104_1",
+        "type": "sensor",
+        "deviceType": "waterSensor",
+        "createdAt": "2024-04-17T12:19:50.000Z",
+        "isReachable": True,
+        "lastSeen": "2024-04-17T12:34:42.000Z",
+        "attributes": {
+            "customName": "Watermelder",
+            "firmwareVersion": "",
+            "hardwareVersion": "",
+            "manufacturer": "SONOFF",
+            "model": "Fake SONOFF Model",
+            "productCode": "E2202",
+            "serialNumber": "0",
+            "waterLeakDetected": False,
+            "permittingJoin": False,
+        },
+        "capabilities": {
+            "canSend": [],
+            "canReceive": [
+"customName"
+        ]
+        },
+        "room": {
+            "id": "f1743e4c-3a87-4f6b-90a4-3e915b8ed753",
+            "name": "Zolder",
+            "color": "ikea_pink_no_8",
+            "icon": "rooms_washing_machine"
+        },
+        "deviceSet": [],
+        "remoteLinks": [],
+        "isHidden": False
+    }
+
+
+
 @pytest.fixture(name="fake_water_sensor_dict")
 def fixture_water_sensor_dict() -> Dict:
     return {
@@ -66,51 +105,16 @@ def test_set_name(fake_water_sensor: WaterSensor, fake_client: FakeDirigeraHub) 
     assert action["data"] == [{"attributes": {"customName": new_name}}]
     assert fake_water_sensor.attributes.custom_name == new_name
 
-def test_dict_to_water_sensor(fake_client: FakeDirigeraHub) -> None:
-    data = {
-        "id": "2b107b0b-73f0-4809-a900-4783273d7104_1",
-        "type": "sensor",
-        "deviceType": "waterSensor",
-        "createdAt": "2024-04-17T12:19:50.000Z",
-        "isReachable": True,
-        "lastSeen": "2024-04-17T12:34:42.000Z",
-        "attributes": {
-            "customName": "Watermelder",
-            "firmwareVersion": "1.0.7",
-            "hardwareVersion": "1",
-            "manufacturer": "IKEA of Sweden",
-            "model": "BADRING Water Leakage Sensor",
-            "productCode": "E2202",
-            "serialNumber": "3410F4FFFE8F815D",
-            "batteryPercentage": 100,
-            "waterLeakDetected": True,
-            "permittingJoin": False,
-            "otaPolicy": "autoUpdate",
-            "otaProgress": 0,
-            "otaScheduleEnd": "00:00",
-            "otaScheduleStart": "00:00",
-            "otaState": "readyToCheck",
-            "otaStatus": "upToDate"
-        },
-        "capabilities": {
-            "canSend": [],
-            "canReceive": [
-            "customName"
-        ]
-        },
-        "room": {
-            "id": "f1743e4c-3a87-4f6b-90a4-3e915b8ed753",
-            "name": "Zolder",
-            "color": "ikea_pink_no_8",
-            "icon": "rooms_washing_machine"
-        },
-        "deviceSet": [],
-        "remoteLinks": [],
-        "isHidden": False
-    }
-    water_sensor = dict_to_water_sensor(data, fake_client)
+def test_dict_to_water_sensor(fake_water_sensor_dict: Dict, fake_client: FakeDirigeraHub) -> None:
+    water_sensor = dict_to_water_sensor(fake_water_sensor_dict, fake_client)
+
     assert water_sensor.dirigera_client == fake_client
-    assert water_sensor.id == data["id"]
-    assert water_sensor.is_reachable == data["isReachable"]
+    assert water_sensor.id == fake_water_sensor_dict["id"]
+    assert water_sensor.is_reachable == fake_water_sensor_dict["isReachable"]
     assert water_sensor.attributes.battery_percentage == 100
     assert water_sensor.attributes.water_leak_detected
+
+def test_dict_to_water_sensor_non_ikea(fake_water_sensor_dict_non_ikea: Dict, fake_client: FakeDirigeraHub) -> None:
+    water_sensor = dict_to_water_sensor(fake_water_sensor_dict_non_ikea, fake_client)
+
+    assert water_sensor.attributes.battery_percentage is None


### PR DESCRIPTION
Non-Ikea motion and water sensors don't seem to provide their battery percentage, and other sensor types have `battery_percentage` set to `Optional[int]`. These were the only two sensor types that required a value to be set.