### PR TITLE
Provide arguments to enable dispatcher handling of network errors

### DIFF
--- a/src/dirigera/hub/hub.py
+++ b/src/dirigera/hub/hub.py
@@ -62,6 +62,8 @@ class Hub(AbstractSmartHomeHub):
         on_data: Any = None,
         on_cont_message: Any = None,
         ping_intervall: int = 60,
+        dispatcher: Any = None,
+        reconnect: int = None,
     ) -> None:
         """
         Create an event listener.
@@ -76,6 +78,8 @@ class Hub(AbstractSmartHomeHub):
             on_data (Any, optional)
             on_cont_message (Any, optional)
             ping_intervall (int, optional): Ping interval in Seconds. Defaults to 60.
+            dispatcher (Any, optional)
+            reconnect (int, optional)
         """
         self.wsapp = websocket.WebSocketApp(
             self.websocket_base_url,
@@ -91,7 +95,8 @@ class Hub(AbstractSmartHomeHub):
         )
 
         self.wsapp.run_forever(
-            sslopt={"cert_reqs": ssl.CERT_NONE}, ping_interval=ping_intervall
+            sslopt={"cert_reqs": ssl.CERT_NONE}, ping_interval=ping_intervall,
+            dispatcher=dispatcher, reconnect=reconnect
         )
 
     def stop_event_listener(self) -> None:


### PR DESCRIPTION
This simple patch adds `dispatcher` and `reconnect` arguments to create_event_listener()
These are passed to the WebSocketApp `run_forever()` method to allow recovery from network errors
See https://github.com/websocket-client/websocket-client/tree/10d9159af9ba1ecb76e0ebb6a04edfd990eacbbb?tab=readme-ov-file#long-lived-connection

I've verified that if the websocket socket is closed due to network errors (as opposed to the DIRIGERA hub inactivity close, which is a "normal" status 1000 event), without this, the dirigera `create_event_listener` loop will exit.
With these arguments, one can follow the method on the websocket-client README to use a dispatcher such as `rel` to handle this, and all is well.

ps - thank you for contributing this library, it's been immensely helpful and i deeply appreciate it